### PR TITLE
Load manifest before http server listen

### DIFF
--- a/server.js
+++ b/server.js
@@ -190,10 +190,10 @@ app.post('/*', middleware);
 
 const port = process.env.http_port || 3000;
 
-app.listen(port, () => {
-    initManifest().then(() => {
+initManifest().then(() => {
+    app.listen(port, () => {
         console.log(`node12 listening on port: ${port}`)
-    }).catch(err => {
-        console.error(err);
     });
+}).catch(err => {
+    console.error(err);
 });


### PR DESCRIPTION
## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [ ] I made my own code-review before requesting one

## Description of the changes
The manifest must be loaded before accepting HTTP requests, otherwise it is possible that during a short period of time the requests go to error
